### PR TITLE
Fix search query

### DIFF
--- a/nweb-server/templates/nav.html
+++ b/nweb-server/templates/nav.html
@@ -16,7 +16,7 @@
             <li><a href="#">Profile</a></li>
             <li><a href="#">Help</a></li> -->
           </ul>
-          <form class="navbar-form navbar-right">
+          <form class="navbar-form navbar-right" action="{{ url_for('search') }}" name="search">
             <input type="text" class="form-control" value="{{query}}" name="q" placeholder="Search..." />
             <input type="submit" value="" style="display: none"/>
           </form>


### PR DESCRIPTION
The search query broke when it got refactored into better templates
because the form didn't have an action defined. I defined the action as
the url for the search function, so it will work no matter where we put
it now.